### PR TITLE
fix(ui): corrigir responsividade do tabuleiro e add titulo

### DIFF
--- a/draw.py
+++ b/draw.py
@@ -1,5 +1,5 @@
 import pygame
-from settings import TILE_SIZE, HEADER_HEIGHT, COLORS, MAX_FONT_SIZE, MIN_FONT_SIZE
+from settings import COLORS, MAX_FONT_SIZE, MIN_FONT_SIZE, COLOR_TOP, COLOR_BOTTOM
 
 font_cache = {}
 surface_cache = {}
@@ -53,7 +53,17 @@ def draw_grid(screen, board):
             pygame.draw.rect(screen, (0, 0, 0), rect, 2)
 
 def draw_board(screen, board, tiles, score, font, score_font, game_over, music_on, icon_on, icon_off, icon_restart):
-    screen.fill((30, 30, 30))
+    # Full responsive draw: compute sizes and fonts from current screen size
+    width, height = screen.get_size()
+    # Draw background gradient using project colors
+    gradient = pygame.Surface((width, height))
+    for y in range(height):
+        ratio = y / max(1, height)
+        r = int(COLOR_TOP[0] * (1 - ratio) + COLOR_BOTTOM[0] * ratio)
+        g = int(COLOR_TOP[1] * (1 - ratio) + COLOR_BOTTOM[1] * ratio)
+        b = int(COLOR_TOP[2] * (1 - ratio) + COLOR_BOTTOM[2] * ratio)
+        pygame.draw.line(gradient, (r, g, b), (0, y), (width, y))
+    screen.blit(gradient, (0, 0))
 
     width, height = screen.get_size()
     board_size = len(board)
@@ -66,12 +76,26 @@ def draw_board(screen, board, tiles, score, font, score_font, game_over, music_o
     offset_x = (width - board_pixel_width) // 2
     offset_y = header_height + ((height - header_height) - board_pixel_height) // 2
 
-    # Score
+    # Dynamically create fonts if not provided so text scales with window
+    if score_font is None:
+        score_font_size = max(14, min(48, tile_size // 3))
+        score_font = pygame.font.SysFont("Arial", score_font_size, bold=True)
+    if font is None:
+        font_size = max(12, min(36, tile_size // 4))
+        font = pygame.font.SysFont("Arial", font_size, bold=True)
+
+    # Title (left-aligned above score) and Score
+    top_margin = max(10, int(height * 0.03))  # distância da parte superior
+    title_color = (255, 180, 60)  # laranja
+    title_surface = score_font.render("BCC2048", True, title_color)
+    title_x = offset_x
+    title_y = top_margin
+    screen.blit(title_surface, (title_x, title_y))
+
     score_text = score_font.render(f"Pontos: {score}", True, (255, 255, 255))
     score_x = offset_x
-    score_y = offset_y - score_text.get_height() - 10
-    if score_y < 5:
-        score_y = 5
+    # Coloca a pontuação logo abaixo do título com pequeno espaçamento
+    score_y = title_y + title_surface.get_height() + max(6, int(height * 0.01))
     screen.blit(score_text, (score_x, score_y))
 
     music_button_rect = None

--- a/draw.py
+++ b/draw.py
@@ -32,7 +32,6 @@ def draw_grid(screen, board):
     width, height = screen.get_size()
     board_size = len(board)
     header_height = int(height * 0.12)
-    # Limitar o tabuleiro a 90% da largura e 85% da altura útil
     max_board_width = int(width * 0.9)
     max_board_height = int((height - header_height) * 0.85)
     tile_size = min(max_board_width // board_size, max_board_height // board_size)
@@ -53,9 +52,9 @@ def draw_grid(screen, board):
             pygame.draw.rect(screen, (0, 0, 0), rect, 2)
 
 def draw_board(screen, board, tiles, score, font, score_font, game_over, music_on, icon_on, icon_off, icon_restart):
-    # Full responsive draw: compute sizes and fonts from current screen size
+    #Responsividade
     width, height = screen.get_size()
-    # Draw background gradient using project colors
+    #BG gradiente
     gradient = pygame.Surface((width, height))
     for y in range(height):
         ratio = y / max(1, height)
@@ -76,7 +75,6 @@ def draw_board(screen, board, tiles, score, font, score_font, game_over, music_o
     offset_x = (width - board_pixel_width) // 2
     offset_y = header_height + ((height - header_height) - board_pixel_height) // 2
 
-    # Dynamically create fonts if not provided so text scales with window
     if score_font is None:
         score_font_size = max(14, min(48, tile_size // 3))
         score_font = pygame.font.SysFont("Arial", score_font_size, bold=True)
@@ -84,7 +82,7 @@ def draw_board(screen, board, tiles, score, font, score_font, game_over, music_o
         font_size = max(12, min(36, tile_size // 4))
         font = pygame.font.SysFont("Arial", font_size, bold=True)
 
-    # Title (left-aligned above score) and Score
+    # Titulo acima do score
     top_margin = max(10, int(height * 0.03))  # distância da parte superior
     title_color = (255, 180, 60)  # laranja
     title_surface = score_font.render("BCC2048", True, title_color)
@@ -94,7 +92,6 @@ def draw_board(screen, board, tiles, score, font, score_font, game_over, music_o
 
     score_text = score_font.render(f"Pontos: {score}", True, (255, 255, 255))
     score_x = offset_x
-    # Coloca a pontuação logo abaixo do título com pequeno espaçamento
     score_y = title_y + title_surface.get_height() + max(6, int(height * 0.01))
     screen.blit(score_text, (score_x, score_y))
 

--- a/main.py
+++ b/main.py
@@ -281,9 +281,7 @@ def run_game():
     else:
         show_menu(screen, music_on, None, None)
 
-    # Keep the resizable screen created for the menu so the board remains responsive.
-    # Don't reset to a fixed WINDOW_SIZE here. Fonts for the board will be calculated
-    # dynamically inside the drawing routine so they scale with the window.
+    #Responsividade
     pygame.display.set_caption("2048 BCC - PyGame")
 
     board, tiles, score = restart_game()

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import math
 import sys
 from board import create_board, spawn_tile, move, is_game_over, are_animations_running, cleanup_merged_tiles
 from draw import draw_board
-from settings import WINDOW_SIZE, HEADER_HEIGHT
+from settings import WINDOW_SIZE, HEADER_HEIGHT, COLOR_TOP, COLOR_BOTTOM
 
 # Constantes do menu
 SPAWN_DURATION = 1.5
@@ -12,8 +12,6 @@ PULSE_INTENSITY = 0.05
 MENU_FPS = 60
 
 # Cores
-COLOR_TOP = (40, 0, 60)
-COLOR_BOTTOM = (0, 0, 80)
 TITLE_COLOR = (255, 215, 0)
 SUBTITLE_COLOR = (200, 200, 255)
 BUTTON_TEXT_NORMAL = (180, 180, 180)
@@ -283,10 +281,10 @@ def run_game():
     else:
         show_menu(screen, music_on, None, None)
 
-    screen = pygame.display.set_mode((WINDOW_SIZE, WINDOW_SIZE + HEADER_HEIGHT))
+    # Keep the resizable screen created for the menu so the board remains responsive.
+    # Don't reset to a fixed WINDOW_SIZE here. Fonts for the board will be calculated
+    # dynamically inside the drawing routine so they scale with the window.
     pygame.display.set_caption("2048 BCC - PyGame")
-    font = pygame.font.SysFont("Arial", 20, bold=True)
-    score_font = pygame.font.SysFont("Arial", 24, bold=True)
 
     board, tiles, score = restart_game()
     clock = pygame.time.Clock()
@@ -345,7 +343,7 @@ def run_game():
             game_over = True
             
         music_button_rect, restart_button_rect = draw_board(
-            screen, board, tiles, score, font, score_font, game_over,
+            screen, board, tiles, score, None, None, game_over,
             music_on, icon_on, icon_off, icon_restart
         )
         

--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,7 @@ TILE_SIZE = WINDOW_SIZE // BOARD_SIZE
 FONT_SIZE = 20
 HEADER_HEIGHT = 60
 
-# Background gradient colors (used by menu and board)
+# BG
 COLOR_TOP = (40, 0, 60)
 COLOR_BOTTOM = (0, 0, 80)
 

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,10 @@ TILE_SIZE = WINDOW_SIZE // BOARD_SIZE
 FONT_SIZE = 20
 HEADER_HEIGHT = 60
 
+# Background gradient colors (used by menu and board)
+COLOR_TOP = (40, 0, 60)
+COLOR_BOTTOM = (0, 0, 80)
+
 MERGE_RULES = {
     ("IP", "IP"): ("POO", 2),
     ("POO", "POO"): ("AED I", 4),


### PR DESCRIPTION
- Restaura a responsividade após alterações recentes (centraliza + maximizar tela)
- Adiciona gradiente de fundo usando `COLOR_TOP` e `COLOR_BOTTOM` na parte do BG do tabuleiro
- Alinha o título "BCC2048" à esquerda, acima da pontuação